### PR TITLE
fix(numpy): Enable the package to be used when numpy is missing

### DIFF
--- a/ladybug_radiance/study/directsun.py
+++ b/ladybug_radiance/study/directsun.py
@@ -1,6 +1,12 @@
 """Class for visualizing the direct sun hours falling onto a mesh."""
 from __future__ import division
 
+try:  # first, assume we are in cPython and numpy is installed
+    from typing import Tuple
+    import numpy as np
+except Exception:  # we are in IronPython or numpy is not installed
+    np, Tuple = None, None
+
 from ladybug_geometry.bounding import bounding_box
 from ladybug_geometry.geometry3d import Vector3D, Mesh3D, Face3D
 from ladybug.datatype.time import Time
@@ -209,7 +215,12 @@ class DirectSunStudy(object):
             self._compute_intersection_matrix()
         # sum the intersection and sky matrices
         t_step = self.timestep
-        self._direct_sun_hours = (self._intersection_matrix.sum(axis=1) / t_step).tolist()
+        if np is None:  # perform the calculation on float numbers
+            self._direct_sun_hours = \
+                [sum(int_list) / t_step for int_list in self._intersection_matrix]
+        else:  # perform the calculation with numpy matrices
+            self._direct_sun_hours = \
+                (self._intersection_matrix.sum(axis=1) / t_step).tolist()
 
     def draw(self, legend_parameters=None):
         """Draw a colored study_mesh, compass, graphic/legend, and title.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ladybug-core>=0.41.30
-numpy>=1.21.6
+numpy>=1.21.6;python_version>='3.6'


### PR DESCRIPTION
It seems that I was wrong that just keeping the numpy import out of the SkyMatrix class would result in no effect the Grasshopper plugin or the IronPython environment.

So this commit makes the package functional in cases where numpy is not installed or the environment is IronPython. When using the package in IronPython, the only thing to be aware of is that the slower text-file parsing method will be used in place of the faster numpy one.